### PR TITLE
add share job data workflow

### DIFF
--- a/.github/workflows/share_job_data.yml
+++ b/.github/workflows/share_job_data.yml
@@ -1,0 +1,17 @@
+name: Share job data
+on: push
+jobs:
+  before:
+    runs-on: ubuntu-latest
+    steps:
+      - id: generate
+        run: echo "result=Hello" >> "${GITHUB_OUTPUT}"
+    outputs:
+      result: ${{ steps.generate.outputs.result }}
+  after:
+    runs-on: ubuntu-latest
+    needs: [before]
+    steps:
+      - env:
+          RESULT: ${{ needs.before.outputs.result }}
+        run: echo "${RESULT}"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to share job data between jobs. The most important change includes the creation of a new workflow file, `.github/workflows/share_job_data.yml`.

New GitHub Actions workflow:

* [`.github/workflows/share_job_data.yml`](diffhunk://#diff-a62204b9609f20cc4e01ba7551f7998f47b72340e825af89ce9f8754950fd4e1R1-R17): Added a new workflow to share job data between jobs using outputs and environment variables.